### PR TITLE
Make libintl-lite work more like the gettext vesion

### DIFF
--- a/internal/libintl.cpp
+++ b/internal/libintl.cpp
@@ -153,12 +153,25 @@ libintl_lite_bool_t loadMessageCatalogFile(const char* domain, FILE* moFile)
 	}
 }
 
-libintl_lite_bool_t bindtextdomain(const char* domain, const char* moFilePath)
+libintl_lite_bool_t bindtextdomain(const char* domain, const char* dirname)
 {
-	return loadMessageCatalog( domain, moFilePath );
+	char moFilePath[1024];
+	char *lang;
+
+	lang = getenv ("LANGUAGE");
+	if (lang == NULL)
+	{
+		return LIBINTL_LITE_BOOL_FALSE;
+	}
+
+	memset(moFilePath, 0, 1024);
+
+	snprintf(moFilePath, 1023, "%s/%s/LC_MESSAGES/%s.mo", dirname, lang, domain);
+
+	return loadMessageCatalog(domain, moFilePath);
 }
 
-libintl_lite_bool_t bind_textdomain_codeset(const char* domain, const char* moFilePath)
+libintl_lite_bool_t bind_textdomain_codeset(const char* domain, const char* codeset)
 {
 	// not implemented yet
 	return LIBINTL_LITE_BOOL_FALSE;

--- a/libintl.h
+++ b/libintl.h
@@ -61,9 +61,9 @@ typedef int libintl_lite_bool_t;
 LIBINTL_LITE_API libintl_lite_bool_t loadMessageCatalog(const char* domain, const char* moFilePath);
 LIBINTL_LITE_API libintl_lite_bool_t loadMessageCatalogFile(const char* domain, FILE* moFile);
 
-LIBINTL_LITE_API libintl_lite_bool_t bindtextdomain(const char* domain, const char* moFilePath);
+LIBINTL_LITE_API libintl_lite_bool_t bindtextdomain(const char* domain, const char* dirname);
 
-LIBINTL_LITE_API libintl_lite_bool_t bind_textdomain_codeset(const char* domain, const char* moFilePath);
+LIBINTL_LITE_API libintl_lite_bool_t bind_textdomain_codeset(const char* domain, const char* codeset);
 
 /**
  * Closes a message catalog for the specified domain and releases its obtained resources.


### PR DESCRIPTION
Hi,

When used with applications that normally link to the gettext version of libintl you don't get the wanted catalogs opened. This patch does change the way this library woks, but makes it work for Kate on Windows. The change makes bindtextdomain() bind_textdomain_codeset() work more like the gettext version.
I think Kate is not the only application that could start using this library on Windows, Android and maybe iOS.

Regards,
  Kåre