### PR TITLE
Add CMake package config files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.a
 *.o
 
+build/
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,41 @@
 cmake_minimum_required(VERSION 3.0)
+project(LibIntl VERSION 1.0)
 
 include(GNUInstallDirs)
 
 add_library(intl STATIC internal/libintl.cpp)
+target_include_directories(intl PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+set_target_properties(intl PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/libintl.h)
 
-install(FILES libintl.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(TARGETS intl DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS intl
+        EXPORT LibIntlTargets
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include
+)
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+    LibIntlConfigVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(EXPORT LibIntlTargets
+        FILE LibIntlTargets.cmake
+        DESTINATION "lib/cmake"
+)
+
+configure_package_config_file(
+    LibIntlConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/LibIntlConfig.cmake"
+    INSTALL_DESTINATION "lib/cmake"
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/LibIntlConfig.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/LibIntlConfigVersion.cmake"
+        DESTINATION "lib/cmake"
+)

--- a/LibIntlConfig.cmake.in
+++ b/LibIntlConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/LibIntlTargets.cmake")
+check_required_components(LibIntl)

--- a/LibIntlConfig.cmake.in
+++ b/LibIntlConfig.cmake.in
@@ -1,4 +1,8 @@
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/LibIntlTargets.cmake")
+
+set_and_check(LibIntl_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(LibIntl_LIBRARY "${PACKAGE_PREFIX_DIR}/lib/libintl.a")
+
 check_required_components(LibIntl)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ Build with Android NDK and cmake
 Build script is configured via environment variables, but you can always override them in command line:
 
 ```bash
-ANDROID_SDK_ROOT="<sdk>" \
-ANDROID_NDK_ROOT="<ndk>" \
-BUILD_ARCH="<arch>" \
+ANDROID_SDK_ROOT="/path/to/android/sdk" \
+ANDROID_NDK_ROOT="/path/to/android/ndk" \
+ANDROID_SDK_CMAKE_VERSION="3.18.1" \
+ANDROID_PLATFORM="21" \
+ANDROID_ABI="armeabi-v7a,arm64-v8a" \
 ./build-android-cmake.sh
 ```
 
-Where `ANDROID_SDK_ROOT` is path to Android SDK, it should contain proper version of cmake. `ANDROID_NDK_ROOT` is path to Android NDK, can be `$ANDROID_SDK_ROOT/ndk/<version>`. `BUILD_ARCH` is comma separated list, eg `armebi-v7a,arm64-v8a,x86,x86_64`.
+Where `ANDROID_SDK_ROOT` is path to Android SDK, it should contain proper version of cmake. `ANDROID_NDK_ROOT` is path to Android NDK, can be `$ANDROID_SDK_ROOT/ndk/<version>`. `ANDROID_ABI` is comma separated list, eg `armeabi-v7a,arm64-v8a,x86,x86_64`.
 
 Build artifacts are stored in `out/libintl-lite/<arch>`. You can use them via `find_package(LibIntl)` as normal cmake packages.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,22 @@ libintl-lite is a simple (but less powerful) GNU gettext libintl replacement ori
 
 The library does not depends upon any library except the standard C++ library and the STL, thus making it well suited for platforms like Android.
 
+Build with Android NDK and cmake
+===============
+
+Build script is configured via environment variables, but you can always override them in command line:
+
+```bash
+ANDROID_SDK_ROOT="<sdk>" \
+ANDROID_NDK_ROOT="<ndk>" \
+BUILD_ARCH="<arch>" \
+./build-android-cmake.sh
+```
+
+Where `ANDROID_SDK_ROOT` is path to Android SDK, it should contain proper version of cmake. `ANDROID_NDK_ROOT` is path to Android NDK, can be `$ANDROID_SDK_ROOT/ndk/<version>`. `BUILD_ARCH` is comma separated list, eg `armebi-v7a,arm64-v8a,x86,x86_64`.
+
+Build artifacts are stored in `out/libintl-lite/<arch>`. You can use them via `find_package(LibIntl)` as normal cmake packages.
+
 Where to get help?
 ===============
 

--- a/build-android-cmake.sh
+++ b/build-android-cmake.sh
@@ -1,33 +1,53 @@
 #!/usr/bin/env bash
 
+CMAKE=""
+
 build_libintl() {
     echo ">>> Building fmt for $1"
-    "$ANDROID_SDK_ROOT"/cmake/3.18.1/bin/cmake -B build \
+    "$CMAKE" -B build \
         -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_ROOT"/build/cmake/android.toolchain.cmake \
         -DANDROID_ABI="$1" \
-        -DANDROID_NATIVE_API_LEVEL=21 \
+        -DANDROID_PLATFORM="$ANDROID_PLATFORM" \
+        -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=out/libintl-lite/"$1" \
         .
-    "$ANDROID_SDK_ROOT"/cmake/3.18.1/bin/cmake --build build
-    "$ANDROID_SDK_ROOT"/cmake/3.18.1/bin/cmake --build build --target install
+    "$CMAKE" --build build
+    "$CMAKE" --build build --target install
 }
 
 if [ -z "${ANDROID_SDK_ROOT}" ]; then
-    echo "ANDROID_SDK_ROOT not set."
+    echo "ANDROID_SDK_ROOT should be set to Android SDK path."
     exit 1
 fi
 
 if [ -z "${ANDROID_NDK_ROOT}" ]; then
-    echo "ANDROID_NDK_ROOT not set."
+    echo "ANDROID_NDK_ROOT should be set to Android NDK path."
     exit 1
 fi
 
-if [ -z "${BUILD_ARCH}" ]; then
-    echo "BUILD_ARCH not set; can be a ',' separated list."
+if [ -z "${ANDROID_SDK_CMAKE_VERSION}" ]; then
+    echo "ANDROID_SDK_CMAKE_VERSION should be set to desired cmake version in \$ANDROID_SDK_ROOT/cmake. eg. 3.18.1"
     exit 1
 fi
 
-IFS=',' read -ra ARCH <<< "${BUILD_ARCH}"
+if [ -z "${ANDROID_PLATFORM}" ]; then
+    echo "ANDROID_PLATFORM should be set to minimum API level supported by the library. eg. 21"
+    exit 1
+fi
+
+if [ -z "${ANDROID_ABI}" ]; then
+    echo "ANDROID_ABI not set; can be a ',' separated list. eg. armeabi-v7a,arm64-v8a"
+    exit 1
+fi
+
+CMAKE="$ANDROID_SDK_ROOT/cmake/$ANDROID_SDK_CMAKE_VERSION/bin/cmake"
+
+if [ ! -f "$CMAKE" ]; then
+    echo "Cannot find cmake: '$CMAKE'"
+    exit 1
+fi
+
+IFS=',' read -ra ARCH <<< "${ANDROID_ABI}"
 
 for a in "${ARCH[@]}"; do
   build_libintl "$a"

--- a/build-android-cmake.sh
+++ b/build-android-cmake.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+build_libintl() {
+    echo ">>> Building fmt for $1"
+    "$ANDROID_SDK_ROOT"/cmake/3.18.1/bin/cmake -B build \
+        -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_ROOT"/build/cmake/android.toolchain.cmake \
+        -DANDROID_ABI="$1" \
+        -DANDROID_NATIVE_API_LEVEL=21 \
+        -DCMAKE_INSTALL_PREFIX=out/libintl-lite/"$1" \
+        .
+    "$ANDROID_SDK_ROOT"/cmake/3.18.1/bin/cmake --build build
+    "$ANDROID_SDK_ROOT"/cmake/3.18.1/bin/cmake --build build --target install
+}
+
+if [ -z "${ANDROID_SDK_ROOT}" ]; then
+    echo "ANDROID_SDK_ROOT not set."
+    exit 1
+fi
+
+if [ -z "${ANDROID_NDK_ROOT}" ]; then
+    echo "ANDROID_NDK_ROOT not set."
+    exit 1
+fi
+
+if [ -z "${BUILD_ARCH}" ]; then
+    echo "BUILD_ARCH not set; can be a ',' separated list."
+    exit 1
+fi
+
+IFS=',' read -ra ARCH <<< "${BUILD_ARCH}"
+
+for a in "${ARCH[@]}"; do
+  build_libintl "$a"
+done

--- a/build-android-cmake.sh
+++ b/build-android-cmake.sh
@@ -8,6 +8,7 @@ build_libintl() {
         -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_ROOT"/build/cmake/android.toolchain.cmake \
         -DANDROID_ABI="$1" \
         -DANDROID_PLATFORM="$ANDROID_PLATFORM" \
+        -DANDROID_STL=c++_shared \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=out/libintl-lite/"$1" \
         .

--- a/build-android-cmake.sh
+++ b/build-android-cmake.sh
@@ -3,7 +3,7 @@
 CMAKE=""
 
 build_libintl() {
-    echo ">>> Building fmt for $1"
+    echo ">>> Building libintl for $1"
     "$CMAKE" -B build \
         -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_ROOT"/build/cmake/android.toolchain.cmake \
         -DANDROID_ABI="$1" \

--- a/build-android-cmake.sh
+++ b/build-android-cmake.sh
@@ -13,6 +13,7 @@ build_libintl() {
         .
     "$CMAKE" --build build
     "$CMAKE" --build build --target install
+    rm -rf ./build
 }
 
 if [ -z "${ANDROID_SDK_ROOT}" ]; then


### PR DESCRIPTION
This PR introduces CMake package config files, which simplify some steps to use this project on Android.

A script to build libraries for multiple Android ABIs is included as well, and its usage is included in README.md.