### PR TITLE
Locate mo files based on LANGUAGE environment.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 project(LibIntl VERSION 1.0)
 
-set(CMAKE_CXX_STANDARD 17)
-
 include(GNUInstallDirs)
 
 add_library(intl STATIC internal/libintl.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0)
 project(LibIntl VERSION 1.0)
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(GNUInstallDirs)
 
 add_library(intl STATIC internal/libintl.cpp)

--- a/LibIntlConfig.cmake.in
+++ b/LibIntlConfig.cmake.in
@@ -4,5 +4,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/LibIntlTargets.cmake")
 
 set_and_check(LibIntl_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
 set_and_check(LibIntl_LIBRARY "${PACKAGE_PREFIX_DIR}/lib/libintl.a")
+add_library(LibIntl::LibIntl ALIAS intl)
 
 check_required_components(LibIntl)

--- a/internal/Util.hpp
+++ b/internal/Util.hpp
@@ -27,6 +27,8 @@ DEALINGS IN THE SOFTWARE.
 #ifndef LIBINTL_INTERNAL_UTIL_HPP_
 #define LIBINTL_INTERNAL_UTIL_HPP_
 
+#include <vector>
+
 #if defined(WIN32) || defined(WINCE)
 typedef unsigned int uint32_t;
 #else
@@ -212,6 +214,21 @@ static bool loadMoFileStringsToArray(FILE* moFile,
 	}
 
 	return true;
+}
+
+static std::vector<std::string> buildMoFilePaths(const char *domain) {
+	std::string languages = getenv("LANGUAGE");
+	std::vector<std::string> paths {""};
+	std::string slash = "/";
+	size_t pos = 0;
+	do {
+		pos = languages.find(":");
+		std::string lang = languages.substr(0, pos);
+		if (lang.empty()) break;
+		paths.emplace_back(slash + lang + "/LC_MESSAGES/" + domain + ".mo");
+		languages.erase(0, pos + 1);
+	} while (pos != std::string::npos);
+	return paths;
 }
 
 } // namespace internal

--- a/internal/Util.hpp
+++ b/internal/Util.hpp
@@ -216,18 +216,25 @@ static bool loadMoFileStringsToArray(FILE* moFile,
 	return true;
 }
 
-static std::vector<std::string> buildMoFilePaths(const char *domain) {
+static std::vector<std::string> buildMoFilePaths(const char *domain)
+{
 	std::string languages = getenv("LANGUAGE");
 	std::vector<std::string> paths {""};
 	std::string slash = "/";
+	const size_t length = languages.size();
 	size_t pos = 0;
-	do {
-		pos = languages.find(":");
-		std::string lang = languages.substr(0, pos);
-		if (lang.empty()) break;
+	size_t colon = 0;
+	while (pos <= length)
+	{
+		colon = languages.find(':', pos);
+		if (colon == std::string::npos)
+		{
+			colon = length;
+		}
+		std::string lang = languages.substr(pos, colon - pos);
 		paths.emplace_back(slash + lang + "/LC_MESSAGES/" + domain + ".mo");
-		languages.erase(0, pos + 1);
-	} while (pos != std::string::npos);
+		pos = colon + 1;
+	}
 	return paths;
 }
 

--- a/internal/Util.hpp
+++ b/internal/Util.hpp
@@ -224,16 +224,22 @@ static std::vector<std::string> buildMoFilePaths(const char *domain)
 	const size_t length = languages.size();
 	size_t pos = 0;
 	size_t colon = 0;
-	while (pos <= length)
+	while (pos != length)
 	{
 		colon = languages.find(':', pos);
+		std::string lang = languages.substr(pos, colon - pos);
+		if (!lang.empty())
+		{
+			paths.emplace_back(slash + lang + "/LC_MESSAGES/" + domain + ".mo");
+		}
 		if (colon == std::string::npos)
 		{
-			colon = length;
+			break;
 		}
-		std::string lang = languages.substr(pos, colon - pos);
-		paths.emplace_back(slash + lang + "/LC_MESSAGES/" + domain + ".mo");
-		pos = colon + 1;
+		else
+		{
+			pos = colon + 1;
+		}
 	}
 	return paths;
 }

--- a/internal/libintl.cpp
+++ b/internal/libintl.cpp
@@ -50,9 +50,9 @@ using namespace libintllite::internal;
 static char* currentDefaultDomain = NULL;
 static map<char*, MessageCatalog*> loadedMessageCatalogPtrsByDomain;
 
-libintl_lite_bool_t loadMessageCatalog(const char* domain, const char* moFilePath)
+libintl_lite_bool_t loadMessageCatalog(const char* domain, const char* moFilesRoot)
 {
-	if (!moFilePath || !domain)
+	if (!moFilesRoot || !domain)
 	{
 		return LIBINTL_LITE_BOOL_FALSE;
 	}
@@ -60,10 +60,9 @@ libintl_lite_bool_t loadMessageCatalog(const char* domain, const char* moFilePat
 	FILE* moFile = NULL;
 	CloseFileHandleGuard closeFileHandleGuard(moFile);
 
-	string moFilePathStr = moFilePath;
 	for (const string &path : buildMoFilePaths(domain))
 	{
-		string fullPath = moFilePathStr + path;
+		string fullPath = moFilesRoot + path;
 		error_code error;
 		if (filesystem::is_regular_file(fullPath, error))
 		{

--- a/internal/libintl.cpp
+++ b/internal/libintl.cpp
@@ -28,7 +28,6 @@ DEALINGS IN THE SOFTWARE.
 
 #include <map>
 #include <string>
-#include <filesystem>
 
 #include <stdlib.h>
 #include <string.h>
@@ -63,20 +62,14 @@ libintl_lite_bool_t loadMessageCatalog(const char* domain, const char* moFilesRo
 	for (const string &path : buildMoFilePaths(domain))
 	{
 		string fullPath = moFilesRoot + path;
-		error_code error;
-		if (filesystem::is_regular_file(fullPath, error))
+		moFile = fopen(fullPath.c_str(), "rb");
+		if (loadMessageCatalogFile(domain, moFile) == LIBINTL_LITE_BOOL_TRUE)
 		{
-			moFile = fopen(fullPath.c_str(), "rb");
-			if (moFile) break;
+			return LIBINTL_LITE_BOOL_TRUE;
 		}
 	}
 
-	if (!moFile)
-	{
-		return LIBINTL_LITE_BOOL_FALSE;
-	}
-
-	return loadMessageCatalogFile(domain, moFile);
+	return LIBINTL_LITE_BOOL_FALSE;
 }
 
 libintl_lite_bool_t loadMessageCatalogFile(const char* domain, FILE* moFile)

--- a/internal/libintl.cpp
+++ b/internal/libintl.cpp
@@ -28,6 +28,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include <map>
 #include <string>
+#include <filesystem>
 
 #include <stdlib.h>
 #include <string.h>
@@ -58,8 +59,19 @@ libintl_lite_bool_t loadMessageCatalog(const char* domain, const char* moFilePat
 
 	FILE* moFile = NULL;
 	CloseFileHandleGuard closeFileHandleGuard(moFile);
-	moFile = fopen(moFilePath, "rb");
-	
+
+	string moFilePathStr = moFilePath;
+	for (const string &path : buildMoFilePaths(domain))
+	{
+		string fullPath = moFilePathStr + path;
+		error_code error;
+		if (filesystem::is_regular_file(fullPath, error))
+		{
+			moFile = fopen(fullPath.c_str(), "rb");
+			if (moFile) break;
+		}
+	}
+
 	if (!moFile)
 	{
 		return LIBINTL_LITE_BOOL_FALSE;


### PR DESCRIPTION
Currently libintl-lite's `bindtextdomain` treat it's second parameter `moFilePath` as path to .mo file.
https://github.com/j-jorge/libintl-lite/blob/f71870eea82e6a1d5f21828ccb7ab604a937eeb9/internal/libintl.cpp#L61
But GNU Gettext can locate locale files base on environment variable `LANG`, `LANGUAGE`, etc.

This PR add the ability to search .mo files based on env `LANGUAGE`, and can handle multiple values separated by `:`. It uses C++ 17's `std::filesystem::is_regular_file` to filter directories, and stops after first regular file. It would first try the given path `moFilePath` (the original behavior), and then `$moFilePath/$lang/LC_MESSAGES/$domain.mo` to mimic GNU Gettext's behavior.

It's still far from full comply of GNU Gettext's behavior, but I'd say it's a step forward. Any changes and suggestions are welcome.