### PR TITLE
Fix build for compilers that default to pre-C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(intl PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 set_target_properties(intl PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/libintl.h)
+target_compile_features(intl PRIVATE cxx_std_11)
 
 install(TARGETS intl
         EXPORT LibIntlTargets


### PR DESCRIPTION
As of commit 52aa2c522bc5, libintl-lite uses initialiser lists,
range-based for loops and std::vector::emplace_back, all of which are
C++11 features. That commit bumped the standard version to 17, but that
was later reverted as part of 3978b2186599, since 17 was no longer
needed for filesystem, but 11 still is.

Thus, mark intl as needing C++11, and using the more modern way rather
than forcing CMAKE_CXX_STANDARD, so that if the compiler already
defaults to newer than C++11 it will do nothing.

This is needed on macOS where the Apple-provided Clang is patched to
default to C++98 rather than C++11 like upstream Clang.